### PR TITLE
build: add babel compilation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .vscode
 node_modules
+/lib/

--- a/package.json
+++ b/package.json
@@ -2,11 +2,13 @@
   "name": "redux-responder",
   "version": "1.0.1",
   "description": "Redux without side effects",
-  "main": "src/index.js",
+  "main": "lib/index.js",
   "typings": "src/index.d.ts",
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha --require @babel/register"
+    "test": "mocha --require @babel/register",
+    "build": "./node_modules/.bin/babel src --out-dir lib",
+    "prepublish": "npm test && npm run build"
   },
   "repository": {
     "type": "git",
@@ -20,6 +22,7 @@
     "flux"
   ],
   "devDependencies": {
+    "@babel/cli": "^7.6.4",
     "@babel/core": "^7.5.5",
     "@babel/preset-env": "^7.5.5",
     "@babel/register": "^7.5.5",


### PR DESCRIPTION
Additions:
* Added @babel/cli dev dependency
* Added folder and contents of /lib to .gitignore. Idea is that the file isn't committed to src, but it is pushed up to npm when publishing the pkg.
* Added build and prepublish scripts

Changes:
* Changed "main:" package.json option to point to "lib/index.js"


Issue: https://github.com/infuse-us/redux-responder/issues/1